### PR TITLE
Casmhms 5821 part2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -252,7 +252,7 @@ services:
     image: artifactory.algol60.net/quay.io/coreos/etcd:v3.4.7
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-reds-etcd:2379
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
     networks:
       - simulation
@@ -322,7 +322,7 @@ services:
   # CAPMC
   #
   cray-capmc:
-    image: artifactory.algol60.net/csm-docker/stable/cray-capmc:2.6.0
+    image: artifactory.algol60.net/csm-docker/stable/cray-capmc:3.1.0
     environment:
       - HSM_URL=http://cray-smd:27779
       - CRAY_VAULT_AUTH_PATH=auth/token/create
@@ -336,6 +336,7 @@ services:
       - LOG_LEVEL=DEBUG
       - TRS_IMPLEMENTATION=LOCAL
       - HSMLOCK_ENABLED=true
+      - PCS_URL=http://cray-power-control:28007
     ports:
       - "27777:27777"
     networks:
@@ -343,6 +344,17 @@ services:
   #
   # PCS
   #
+  cray-power-control-etcd:
+    image: artifactory.algol60.net/quay.io/coreos/etcd:v3.4.7
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-power-control-etcd:2379
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+    networks:
+      - simulation
+      # ports:
+      # - 2379:2379
+      # - 2380:2380
   cray-power-control:
     #TODO: update to stable version when completed and tagged
     image: artifactory.algol60.net/csm-docker/unstable/cray-power-control:0.0.9-20221215001720.53c83da
@@ -360,7 +372,7 @@ services:
       - TRS_IMPLEMENTATION=LOCAL
       - HSMLOCK_ENABLED=true
       - STORAGE=ETCD
-      - ETCD_HOST=etcd
+      - ETCD_HOST=cray-power-control-etcd
       - ETCD_PORT=2379
     ports:
       - "28007:28007"
@@ -371,10 +383,9 @@ services:
   #
   cray-bss-etcd:
     image: artifactory.algol60.net/quay.io/coreos/etcd:v3.4.7
-    hostname: etcd
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-bss-etcd:2379
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
     networks:
       - simulation
@@ -503,7 +514,7 @@ services:
     image: artifactory.algol60.net/quay.io/coreos/etcd:v3.4.7
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-fas-etcd:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-hbtd-etcd:2379
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
     # ports:
     #   - 2379:2379
@@ -529,7 +540,7 @@ services:
     image: artifactory.algol60.net/quay.io/coreos/etcd:v3.4.7
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-fas-etcd:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-hmnfd-etcd:2379
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
     # ports:
     #   - 2379:2379

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -356,8 +356,7 @@ services:
       # - 2379:2379
       # - 2380:2380
   cray-power-control:
-    #TODO: update to stable version when completed and tagged
-    image: artifactory.algol60.net/csm-docker/unstable/cray-power-control:0.0.9-20221215001720.53c83da
+    image: artifactory.algol60.net/csm-docker/stable/cray-power-control:1.0.0
     environment:
       - SMS_SERVER=http://cray-smd:27779
       - CRAY_VAULT_AUTH_PATH=auth/token/create

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -439,7 +439,7 @@ services:
       - TRS_IMPLEMENTATION=LOCAL
       - HSMLOCK_ENABLED=true
       - STORAGE=ETCD
-      - ETCD_HOST=etcd
+      - ETCD_HOST=cray-fas-etcd
       - ETCD_PORT=2379
     networks:
       - simulation

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -248,16 +248,8 @@ services:
   #
   # REDS
   #
-  cray-reds-etcd:
-    image: artifactory.algol60.net/quay.io/coreos/etcd:v3.4.7
-    environment:
-      - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_ADVERTISE_CLIENT_URLS=http://cray-reds-etcd:2379
-      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
-    networks:
-      - simulation
   cray-reds-vault-loader:
-    image: artifactory.algol60.net/csm-docker/stable/cray-reds:1.24.0
+    image: artifactory.algol60.net/csm-docker/stable/cray-reds:2.0.0
     environment:
       CRAY_VAULT_AUTH_PATH: auth/token/create
       CRAY_VAULT_ROLE_FILE: configs/namespace
@@ -275,7 +267,7 @@ services:
     profiles:
       - do-not-start-automatically
   cray-reds:
-    image: artifactory.algol60.net/csm-docker/stable/cray-reds:1.24.0
+    image: artifactory.algol60.net/csm-docker/stable/cray-reds:2.0.0
     environment:
       - HSM_URL=http://cray-smd:27779/hsm/v2
       - CRAY_VAULT_AUTH_PATH=auth/token/create
@@ -286,7 +278,6 @@ services:
       - VAULT_KEYPATH=hms-creds
       - VAULT_SKIP_VERIFY=true
       - VAULT_ENABLED=true
-      - DATASTORE_URL=http://cray-reds-etcd:2379
       - SLS_ADDR=cray-sls:8376/v1
     networks:
       - simulation

--- a/tests/ct/Dockerfile
+++ b/tests/ct/Dockerfile
@@ -20,7 +20,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-FROM artifactory.algol60.net/csm-docker/stable/hms-test:4.0.0
+FROM artifactory.algol60.net/csm-docker/stable/hms-test:5.0.0
 
 COPY integration/ /src/app/integration
 COPY smoke/ /src/app

--- a/tests/ct/integration/test_redfish_power_events.tavern.yaml
+++ b/tests/ct/integration/test_redfish_power_events.tavern.yaml
@@ -72,6 +72,8 @@ stages:
   delay_after: 10 # Wait to allow the event to propagate from RIE to HSM
 
 - name: Verify current power state of node is off with CAPMC
+  delay_after: 5
+  max_retries: 60
   request:
     url: "{capmc_base_url}/capmc/v1/get_xname_status"
     method: POST
@@ -88,6 +90,8 @@ stages:
         - "{node_xname}"
 
 - name: Verify power state in HSM is now Off
+  delay_after: 5
+  max_retries: 60
   request:
     url: "{hsm_base_url}/hsm/v2/State/Components/{node_xname}"
     method: GET


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
* Pulled in stable images for CAPMC Lite and PCS.
* PCS and CAPMC Lite now work properly 
* PCS now has its own dedicated ETCD instance, and fixed hostnames for the other ETCD instances.
* Updated the integration test to retry checking the BMC power state like the PCS/CAPMC tests works.
* Pulled in newer hms-test image for tests docker image.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially resolves CASMHMS-5821 

## Testing

### Tested on:
* Local machine
* Github actions

### Test description:

Integration tests passed, and all of the CAPMC/PCS tavern tests pass: https://cray-hpe.github.io/hms-nightly-integration/main/main/2023-01-23_08-35-33/index.html
## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

